### PR TITLE
128. Longest Consecutive Sequence

### DIFF
--- a/128.py
+++ b/128.py
@@ -4,33 +4,14 @@ class Solution(object):
         :type nums: List[int]
         :rtype: int
         """
-        # con_lens stands for consecutive lengths
-        con_lens = dict()
-        for num in nums:
-            # don't need to do anything if a num already exists
-            if num not in con_lens:
-                # new num - four cases:
-                # 3. num - 1 exists AND num + 1 exists
-                if num - 1 in con_lens and num + 1 in con_lens:
-                    con_lens[num] = con_lens[num - 1] + con_lens[num + 1]
-                    con_lens[num] += 1
-                    con_lens[num - 1] = con_lens[num]
-                    con_lens[num + 1] = con_lens[num]
-                # 1. only num - 1 exists
-                elif num - 1 in con_lens:
-                    con_lens[num - 1] += 1
-                    con_lens[num] = con_lens[num - 1]
-                # 2. only num - 1 exists
-                elif num + 1 in con_lens:
-                    con_lens[num + 1] += 1
-                    con_lens[num] = con_lens[num + 1]
-                # 4. new num is an island
-                else:
-                    con_lens[num] = 1
-
         longest = 0
-        for length in con_lens.values():
-            if length > longest:
-                longest = length
+        nums_set = set(nums)
+        for num in nums:
+            # this is the beginning of a sequence
+            if num - 1 not in nums_set:
+                curr = 1
+                while (num + curr in nums_set):
+                    curr += 1
+                longest = max(curr, longest)
 
         return longest


### PR DESCRIPTION
# Link
https://leetcode.com/problems/longest-consecutive-sequence/description/
# Process
## Attempt 1
 - Tried to track adjacent numbers and keep a large set that would be continuously added to
 - It would not update neighbours correctly
## Attempt 2
- Neighbours were now correctly updated, but needed a chain reaction to get the right value
## Attempt 3
- Switched from `set` to `int`
- Tried to only add self and not neighbours, but this still did not set off a chain reaction
## Attempt 4
- Used a `set` of the original list of numbers allowing for `O(1)` lookup
- Found sequences of numbers by checking if they had a "left neighbour"
- Checked all "right neighbours" for the beginning of a sequence
- Each number is visited at most twice since we only start counting at the beginning of a sequence therefore:
  - Time Complexity: `O(n)`
  - Space Complexity `O(n)`