### PR TITLE
42. Trapping Rain Water

### DIFF
--- a/42.py
+++ b/42.py
@@ -4,49 +4,19 @@ class Solution(object):
         :type height: List[int]
         :rtype: int
         """
-        l, r = 0, 0
+        l, r = 0, len(height) - 1
         trapped = 0
-        # non-increasing monotonic stack
-        stack = []
+        lmax = height[l]
+        rmax = height[r]
 
-        # find our first barrier
-        while r < len(height) and height[r] == 0:
-            r += 1
-
-        # 1. height[0] == 0 : l == 0  < r
-        # 2. height[0] != 0 : l == 0 == r
-        l = r
-
-        # start looking for more barriers
-        r += 1
-        while r < len(height):
-            # TODO: FIX STACK LOGIC
-            # new trough found
-            if len(stack) == 0 or height[r] < stack[-1][1]:
-                stack.append((r, height[r]))
-
-            # new right barrier found
-            if height[r] > stack[-1][1]:
-                while len(stack) > 0:
-                    (width, length) = stack.pop()
-                    # stack is still not empty, so we have an intermediate left barrier
-                    if len(stack) > 0:
-                        left_bar = stack[-1][1]
-                    # stack has been emptied
-                    else:
-                        left_bar = height[l]
-
-                    if height[r] < left_bar:
-                        trapped += (r - width) * (height[r] - length)
-                    else:
-                        trapped += (r - width) * (left_bar - length)
-
-                # current "right barrier" could be an intermediate left barrier
-                stack.append((r, height[r]))
-                # if left barrier was the bottleneck on the last iteration,
-                # we've added all rain possible to the left of the right pointer
-                if height[l] <= height[r]:
-                    l = r
-            r += 1
+        while l < r:
+            if lmax < rmax:
+                l += 1
+                lmax = max(lmax, height[l])
+                trapped += lmax - height[l]
+            else:
+                r -= 1
+                rmax = max(rmax, height[r])
+                trapped += rmax - height[r]
 
         return trapped


### PR DESCRIPTION
# Link
https://leetcode.com/problems/trapping-rain-water/submissions/1441195128/
# Solution
## Attempt 1
- My initial thought was to sweep left to right with two pointers
- The idea was to find valleys and add the collected rainwater along the way
- The valley finding logic was faulty as it would miss "small" valleys
- Started using a decreasing stack to track limiting factors as we went from left to right ("small" valleys)
  - Used this formula `trapped += (r - stack[-1][0]) * (height[r] - stack[-1][1])`
- Adding rainwater from "large" valleys and "small" valleys at the same time would cause redundancy, so "large" valley functionality was removed
- Used the `min(height[l], height[r])` to determine what I thought was the limiting factor and moved the left barrier to indicate that all rain on that side had been added if it was the limiting factor
- This only passed the first test case
## Attempt 2
- Traced through the second example and found that my algorithm was using a wide brush; this had the issue of:
  - overlapping volumes of water
  - trapped water calculated where there was a barrier
- Came up with the idea of intermediate barriers which meant emptying the stack before moving on
  - Not emptying the stack was what was causing the overlaps
- This solution had the problem of not knowing which barriers were actually limiting factors and being able to add the corresponding volumes
## Attempt 3
- Finally used a two-pointer solution that swept into the middle from both sides
- It relied on the fact that there would be one limiting factor at each given index based on previous context from the left and right
- We would always utilize the limiting factor and search for better results (a greater max) from the end that was the limiting factor