### PR TITLE
875. Koko Eating Bananas

### DIFF
--- a/875.py
+++ b/875.py
@@ -7,9 +7,10 @@ class Solution(object):
         """
         # if we have a very generous h, we can eat one banana at a time
         # having a banana-eating rate higher than our largest pile is pointless
+        # O(n)
         l, r = 1, max(piles)
         lowest_eating_rate = r
-        # O(log(n))
+        # O(log(r))
         while l <= r:
             time_taken = 0
             mid = (l + r) // 2


### PR DESCRIPTION
# Link
https://leetcode.com/problems/koko-eating-bananas/
# Process
## Initial Considerations
- Understood this was some sort of `log` problem (binary search)
- Understood that the largest pile (`max(piles)`) would be a limiting factor
- Considered halving the `max`, but we'd have no way to back track
## Solution
### Considerations
- Two pointers `l = 1` and `r = max(piles)` because:
  - If we have a very generous `h`, we can eat one banana at a time
  - Having a banana-eating rate higher than the largest pile is pointless as you can only eat up to that many for our max pile, and it doesn't reduce the amount of sessions required to eat the other smaller piles
### Implementation
- Solution runs in `O(n * log(r))`
- Start by assuming that "lowest eating rate" (`k`) is equal to the max pile size
- Calculate `mid` and squeeze until ideal value is found
- Calculating time taken for Koko to eat all banana piles costs `O(n)` for every `k` value we check
- Any eating rate that takes too long means we should:
  - Increase our eating rate (move the `left` pointer)
- Any eating rate that is within our time (`<=`) means:
  - We are allowed to decrease our eating rate (move the `right` pointer)
  - This will be the lowest viable eating rate we've seen thus far
- Fixed an off-by-one error caused by the `while` condition not checking the `l == r` case