### PR TITLE
19. Remove Nth Node From End of List

### DIFF
--- a/19.py
+++ b/19.py
@@ -19,6 +19,13 @@ class Solution(object):
         :rtype: Optional[ListNode]
         """
         dummy = ListNode(0, head)
+        l, r = dummy, head
+        # we want the offset between the two pointers to be 1 larger than n
+        # so we can stay at "prev" and delete "curr"
+        i = 0
+        while i < n:
+            r = r.next
+            i += 1
 
     def removeNthFromEndSlowFast(self, head, n):
         """

--- a/19.py
+++ b/19.py
@@ -5,6 +5,9 @@
 #         self.next = next
 class Solution(object):
     def removeNthFromEnd(self, head, n):
+        return self.removeNthFromEndSlowFast(head, n)
+
+    def removeNthFromEndSlowFast(self, head, n):
         """
         :type head: Optional[ListNode]
         :type n: int

--- a/19.py
+++ b/19.py
@@ -23,3 +23,7 @@ class Solution(object):
         # fast is pointing to None because we have odd elements
         if not fast:
             sz -= 1
+
+        index = sz - n
+        if index > (sz - 1) // 2:
+            index = sz - 1 - index

--- a/19.py
+++ b/19.py
@@ -28,6 +28,10 @@ class Solution(object):
             sz -= 1
 
         index = sz - n
+        # edge case, we're removing the first element of the list
+        if index == 0:
+            return head.next
+
         # start at 1 because we want to stop right before the element
         i = 1
         curr = head

--- a/19.py
+++ b/19.py
@@ -5,10 +5,19 @@
 #         self.next = next
 class Solution(object):
     def removeNthFromEnd(self, head, n):
+        """
+        :type head: Optional[ListNode]
+        :type n: int
+        :rtype: Optional[ListNode]
+        """
         return self.removeNthFromEndSlowFast(head, n)
 
     def removeNthFromEndSlowFast(self, head, n):
         """
+        Uses fast and slow pointers to calculate the size of the list
+        and determine the index of the node to delete. This algorithm
+        should run twice as fast as using 2 loops since it runs two
+        "half" loops instead of 2 full ones.
         :type head: Optional[ListNode]
         :type n: int
         :rtype: Optional[ListNode]

--- a/19.py
+++ b/19.py
@@ -10,7 +10,7 @@ class Solution(object):
         :type n: int
         :rtype: Optional[ListNode]
         """
-        return self.removeNthFromEndSlowFast(head, n)
+        return self.removeNthFromEndOffset(head, n)
 
     def removeNthFromEndOffset(self, head, n):
         """
@@ -18,6 +18,8 @@ class Solution(object):
         :type n: int
         :rtype: Optional[ListNode]
         """
+        # dummy node removes edge cases where we remove head
+        # including a list size of 1
         dummy = ListNode(0, head)
         l, r = dummy, head
         # we want the offset between the two pointers to be 1 larger than n
@@ -26,6 +28,16 @@ class Solution(object):
         while i < n:
             r = r.next
             i += 1
+
+        # increment both pointers until r reaches the end of the list
+        while r:
+            l = l.next
+            r = r.next
+
+        # l is at the node before our desired "delete" node
+        l.next = l.next.next
+        # return head
+        return dummy.next
 
     def removeNthFromEndSlowFast(self, head, n):
         """

--- a/19.py
+++ b/19.py
@@ -25,5 +25,18 @@ class Solution(object):
             sz -= 1
 
         index = sz - n
+        # start at 1 because we want to stop right before the element
+        i = 1
+        curr = head
+        # element is in the second half of the list
         if index > (sz - 1) // 2:
             index = sz - 1 - index
+            curr = slow
+
+        # loop until we're just before the desired element to remove
+        while i < index:
+            curr = curr.next
+
+        # set prev.next = curr.next to "delete" curr
+        curr.next = curr.next.next
+        return head

--- a/19.py
+++ b/19.py
@@ -1,0 +1,12 @@
+# Definition for singly-linked list.
+# class ListNode(object):
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution(object):
+    def removeNthFromEnd(self, head, n):
+        """
+        :type head: Optional[ListNode]
+        :type n: int
+        :rtype: Optional[ListNode]
+        """

--- a/19.py
+++ b/19.py
@@ -11,6 +11,9 @@ class Solution(object):
         :rtype: Optional[ListNode]
         """
         # input is assumed to be valid: 1 <= n <= sz
+        # base case: valid list with only one element
+        if not head.next:
+            return None
         slow, fast = head, head.next
         # assume two nodes to start
         sz = 2

--- a/19.py
+++ b/19.py
@@ -14,6 +14,7 @@ class Solution(object):
 
     def removeNthFromEndOffset(self, head, n):
         """
+        Uses an offset between a left and right pointer to find "n from the end".
         :type head: Optional[ListNode]
         :type n: int
         :rtype: Optional[ListNode]

--- a/19.py
+++ b/19.py
@@ -12,6 +12,14 @@ class Solution(object):
         """
         return self.removeNthFromEndSlowFast(head, n)
 
+    def removeNthFromEndOffset(self, head, n):
+        """
+        :type head: Optional[ListNode]
+        :type n: int
+        :rtype: Optional[ListNode]
+        """
+        dummy = ListNode(0, head)
+
     def removeNthFromEndSlowFast(self, head, n):
         """
         Uses fast and slow pointers to calculate the size of the list

--- a/19.py
+++ b/19.py
@@ -12,8 +12,14 @@ class Solution(object):
         """
         # input is assumed to be valid: 1 <= n <= sz
         slow, fast = head, head.next
+        # assume two nodes to start
+        sz = 2
         # slow += 1; fast += 2
         while fast and fast.next:
             slow = slow.next
             fast = fast.next.next
-
+            # jump 2 nodes
+            sz += 2
+        # fast is pointing to None because we have odd elements
+        if not fast:
+            sz -= 1

--- a/19.py
+++ b/19.py
@@ -33,12 +33,14 @@ class Solution(object):
         curr = head
         # element is in the second half of the list
         if index > (sz - 1) // 2:
-            index = sz - 1 - index
+            # increment our counter to the midpoint
+            i += (sz - 1) // 2
             curr = slow
 
         # loop until we're just before the desired element to remove
         while i < index:
             curr = curr.next
+            i += 1
 
         # set prev.next = curr.next to "delete" curr
         curr.next = curr.next.next

--- a/19.py
+++ b/19.py
@@ -10,3 +10,10 @@ class Solution(object):
         :type n: int
         :rtype: Optional[ListNode]
         """
+        # input is assumed to be valid: 1 <= n <= sz
+        slow, fast = head, head.next
+        # slow += 1; fast += 2
+        while fast and fast.next:
+            slow = slow.next
+            fast = fast.next.next
+


### PR DESCRIPTION
# Link
https://leetcode.com/problems/remove-nth-node-from-end-of-list/description/
# Process
## Slow/Fast Pointers + Index Solution
- My first thought was to do two loops that would:
  1. Calculate `sz`
  2. Remove the desired node
- I realized I could use `slow`/`fast` pointers to calculate `n` in half the time
  - This would also speed up the deletion loop because if the "delete element" happened to be in the second half of the list we'd have `slow` at the midpoint
- I calculated the index of the node to delete, and had a counter stop right before that index so I could fix `next` pointers
### Issues
- I had two handle two edge cases where the node to delete was `head`
  - This would happen if `index = 0`
  - Or `sz = 1` since we're guaranteed valid input
- I didn't correctly increment the counter to be at the midpoint
- I didn't increment the counter at all during the loop at first lol
## Left/Right + Offset Solution
- After watching the NeetCode video, he describe a solution where you would have two pointers at an offset to know where "n from the end of the list" is
- The `r` pointer finds the end of the list, and the `l` pointer stays behind so we can delete our desired element
- This solution uses a `dummy` node to start
  - This helps increase the offset by 1 so we can stay at the `prev` node (like in the first solution) and fix `next` pointers
  - It also eliminates the edge cases I had in the previous solution where you had to delete `head` since `dummy.next` points to the new head of the list if the old head was deleted