### PR TITLE
104. Maximum Depth of Binary Tree

### DIFF
--- a/104.py
+++ b/104.py
@@ -10,9 +10,17 @@ class Solution(object):
         :type root: Optional[TreeNode]
         :rtype: int
         """
+        return self.maxDepthR(root)
+
+    def maxDepthR(self, root):
+        """
+        Find max depth recursively
+        :type root: Optional[TreeNode]
+        :rtype: int
+        """
         # Null nodes are depth 0
         if not root:
             return 0
         # Check children's heights and add 1 for the current node
         else:
-            return max(self.maxDepth(root.left), self.maxDepth(root.right)) + 1
+            return max(self.maxDepthR(root.left), self.maxDepthR(root.right)) + 1

--- a/104.py
+++ b/104.py
@@ -10,7 +10,7 @@ class Solution(object):
         :type root: Optional[TreeNode]
         :rtype: int
         """
-        return self.maxDepthR(root)
+        return self.maxDepthI_BFS(root)
 
     def maxDepthR(self, root):
         """
@@ -24,3 +24,29 @@ class Solution(object):
         # Check children's heights and add 1 for the current node
         else:
             return max(self.maxDepthR(root.left), self.maxDepthR(root.right)) + 1
+
+    def maxDepthI_BFS(self, root):
+        """
+        Iteratively uses BFS to find max depth
+        Level order traversal means that height = # of levels
+        :type root: Optional[TreeNode]
+        :rtype: int
+        """
+        # empty trees are height 0
+        if not root:
+            return 0
+
+        # initialize queue with root and height 0
+        queue = [root]
+        height = 0
+        while queue:
+            # pop all nodes on a single level
+            for i in range(len(queue)):
+                curr = queue.pop(0)
+                if curr.left:
+                    queue.append(curr.left)
+                if curr.right:
+                    queue.append(curr.right)
+            # increment height by # of levels
+            height += 1
+        return height

--- a/104.py
+++ b/104.py
@@ -1,0 +1,12 @@
+# Definition for a binary tree node.
+# class TreeNode(object):
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution(object):
+    def maxDepth(self, root):
+        """
+        :type root: Optional[TreeNode]
+        :rtype: int
+        """

--- a/104.py
+++ b/104.py
@@ -10,3 +10,9 @@ class Solution(object):
         :type root: Optional[TreeNode]
         :rtype: int
         """
+        # Null nodes are depth 0
+        if not root:
+            return 0
+        # Check children's heights and add 1 for the current node
+        else:
+            return max(self.maxDepth(root.left), self.maxDepth(root.right)) + 1

--- a/104.py
+++ b/104.py
@@ -10,7 +10,7 @@ class Solution(object):
         :type root: Optional[TreeNode]
         :rtype: int
         """
-        return self.maxDepthI_BFS(root)
+        return self.maxDepthI_DFS(root)
 
     def maxDepthR(self, root):
         """
@@ -50,3 +50,21 @@ class Solution(object):
             # increment height by # of levels
             height += 1
         return height
+
+    def maxDepthI_DFS(self, root):
+        """
+        Iteratively uses pre-order DFS to find max depth
+        :type root: Optional[TreeNode]
+        :rtype: int
+        """
+        # initialize stack with depth 1
+        stack = [(root, 1)]
+        max_depth = 0
+        while stack:
+            curr, depth = stack.pop()
+            # increase depth for non-null nodes, and add their children
+            if curr:
+                max_depth = max(max_depth, depth)
+                stack.append((curr.left, depth + 1))
+                stack.append((curr.right, depth + 1))
+        return max_depth


### PR DESCRIPTION
# Link
https://leetcode.com/problems/maximum-depth-of-binary-tree/
# Process
## Recursion
- I already completed this question #35 
- The difference for this question was that leaves were considered depth 1 so I removed the `elif` statement
## Iterative BFS
- Add non-null children to the queue for processing
- Uses level order traversal and counts the "levels" by emptying the queue of a single level before moving on to the next iteration
## Iterative DFS
- Uses pre-order DFS and does logic for non-null nodes
  - `max_depth` is calculated by comparing current node's depth against the previous max
  - Increase depth for children (even null) and add to the stack for processing