### PR TITLE
543. Diameter of Binary Tree

### DIFF
--- a/543.py
+++ b/543.py
@@ -10,13 +10,14 @@ class Solution(object):
         :type root: Optional[TreeNode]
         :rtype: int
         """
-        return self.height_and_max_diameter(root)[1]
+        # return self.height_and_max_diameter(root)[1]
+        return self.diameterOfBinaryTree2(root)
 
     def height_and_max_diameter(self, root):
         """
         Find height and max diameter recursively
         :type root: Optional[TreeNode]
-        :rtype: int
+        :rtype: (int, int)
         """
         # Null nodes are depth 0, and have diameter 0
         if not root:
@@ -29,3 +30,24 @@ class Solution(object):
             diameter = l_height + r_height
             max_diameter = max(diameter, l_diameter, r_diameter)
             return (height, max_diameter)
+
+    def diameterOfBinaryTree2(self, root):
+        """
+        :type root: Optional[TreeNode]
+        :rtype: int
+        """
+        self.max_diameter = 0
+
+        def calculate_height_update_max_diameter(tree):
+            """
+            Returns height and updates max diameter
+            """
+            if not tree:
+                return 0
+            l = calculate_height_update_max_diameter(tree.left)
+            r = calculate_height_update_max_diameter(tree.right)
+            self.max_diameter = max(self.max_diameter, l + r)
+            return max(l, r) + 1
+
+        calculate_height_update_max_diameter(root)
+        return self.max_diameter


### PR DESCRIPTION
# Link
https://leetcode.com/problems/diameter-of-binary-tree/description/
# Process
## Intuitions
- I recognized that the longest path on the `left` and `right` to the `root` would simply be their heights
  - i.e. diameter at root is `l + r`
- However, child trees could have bigger diameters if they used their children (the tree is unbalanced)
## Solution 1 (too slow)
- I had the code find the heights of `left` and `right` to find the `root` diameter
- I also called the function recursively on `left` and `right` to find THEIR max diameter and compare it to `root`
- As expected, this solution was too slow for the last test case on LeetCode because it does a lot of overlapping calculation
## Solution 2 (tuples)
- I redesigned the recursive function to return a tuple of `(height, max_diameter)`
- This way, the `root` could calculate its own diameter using `l_height` and `r_height` and then compare its own diameter to those of its children to see which is greatest
- The parent function would just call the recursive function and return the second value in the tuple
## Solution 3 (member variable + internal function)
- This solution I saw on NeetCode which I think aligned more with how I initially conceptualized the problem in terms of keeping a running `max_diameter`
- It basically just calculates `height` and then updates `max_diameter` as its doing calculations
- Return `max_diameter` at the end