### PR TITLE
146. LRU Cache

### DIFF
--- a/146.py
+++ b/146.py
@@ -49,17 +49,13 @@ class LRUCache(object):
             old_node.prev.next = old_node.next
             old_node.next.prev = old_node.prev
 
-            # add new key usage data (most recently used)
-            new_node = ListNode(value)
-            new_node.prev = self._tail
-            self._tail.next = new_node
-            self._tail = new_node
+        # add new key usage data (most recently used)
+        self._tail.next = ListNode(value)
+        self._tail.next.prev = self._tail
+        self._tail = self._tail.next
 
-            # add new key-value pair
-            self._key_value[key] = new_node
-        else:
-            # updates old key or adds new key-value if there is space
-            self._key_value[key] = value
+        # updates old key or adds new key-value if there is space
+        self._key_value[key] = self._tail
 
 
 # Your LRUCache object will be instantiated and called as such:

--- a/146.py
+++ b/146.py
@@ -21,6 +21,7 @@ class LRUCache(object):
         """
         :type node: ListNode
         """
+        # sever node's ties to delete it from the middle of the list
         node.prev.next = node.next
         node.next.prev - node.prev
 
@@ -28,8 +29,12 @@ class LRUCache(object):
         """
         :type node: ListNode
         """
-        # insert node
-        return
+        # insert node at the "tail" of the list
+        node.prev = self._tail.prev
+        node.next = self._tail
+        # detach old pointers and attach to node
+        self._tail.prev.next = node
+        self._tail.prev = node
 
     def get(self, key):
         """

--- a/146.py
+++ b/146.py
@@ -17,12 +17,20 @@ class LRUCache(object):
         else:
             return -1
 
+        # TODO: update key usage
+
     def put(self, key, value):
         """
         :type key: int
         :type value: int
         :rtype: None
         """
+        if key not in self._key_value and len(self._key_value) >= self._capacity:
+            # TODO: Evict LRU key
+            return
+        else:
+            # updates old key or adds new key-value if there is space
+            self._key_value[key] = value
 
 
 # Your LRUCache object will be instantiated and called as such:

--- a/146.py
+++ b/146.py
@@ -22,11 +22,18 @@ class LRUCache(object):
         :rtype: int
         """
         if key in self._key_value:
-            return self._key_value[key]
+            # upate usage
+            node = self._key_value[key]
+            # delete node from middle of the list
+            node.prev.next = node.next
+            node.next.prev = node.prev
+            # move node to the end of the list
+            self._tail.next = node
+            self._tail = node
+            # return value from key-value pair
+            return node.val
         else:
             return -1
-
-        # TODO: update key usage
 
     def put(self, key, value):
         """

--- a/146.py
+++ b/146.py
@@ -13,8 +13,9 @@ class LRUCache(object):
         self._capacity = capacity
         self._key_value = dict()
         # dummy head and tail to prevent head/tail deletion
-        self._head = ListNode(0, 0)
-        self._tail = ListNode(0, 0)
+        self._head, self._tail = ListNode(0, 0), ListNode(0, 0)
+        self._head.next = self._tail
+        self._tail.prev = self._head
 
     def remove(self, node):
         """

--- a/146.py
+++ b/146.py
@@ -68,12 +68,17 @@ class LRUCache(object):
         # delete existing key from linked list
         if key in self._key_value:
             node = self._key_value[key]
+            # increment head pointer if we delete head
             if node is self._head:
                 self._head = self._head.next
-                # head has no prev
-                node.next.prev = node.prev
-            else:
+            # decerement tail pointer if we delete tail
+            elif node is self._tail:
+                self._tail = self._tail.prev
+
+            # sever any links
+            if node.prev:
                 node.prev.next = node.next
+            if node.next:
                 node.next.prev = node.prev
 
         # empty list

--- a/146.py
+++ b/146.py
@@ -67,13 +67,17 @@ class LRUCache(object):
 
         # delete existing key from linked list
         if key in self._key_value:
-            old_node = self._key_value[key]
-            if old_node.prev:
-                old_node.prev.next = old_node.next
-            if old_node.next:
-                old_node.next.prev = old_node.prev
+            node = self._key_value[key]
+            if node is self._head:
+                self._head = self._head.next
+                # head has no prev
+                node.next.prev = node.prev
+            else:
+                node.prev.next = node.next
+                node.next.prev = node.prev
 
-        if not self._tail:
+        # empty list
+        if not self._head:
             self._head = ListNode(key, value)
             self._tail = self._head
         else:

--- a/146.py
+++ b/146.py
@@ -34,9 +34,23 @@ class LRUCache(object):
         :type value: int
         :rtype: None
         """
+        # no space for a new key
         if key not in self._key_value and len(self._key_value) >= self._capacity:
-            # TODO: Evict LRU key
-            return
+            # delete key-value pair
+            pop_key = self._head.val
+            self._key_value.pop(pop_key)
+
+            # remove old key usage data (remove node from linked list)
+            self._head = self._head.next
+
+            # add new key usage data (most recently used)
+            new_node = ListNode(value)
+            new_node.prev = self._tail
+            self._tail.next = new_node
+            self._tail = new_node
+
+            # add new key-value pair
+            self._key_value[key] = new_node
         else:
             # updates old key or adds new key-value if there is space
             self._key_value[key] = value

--- a/146.py
+++ b/146.py
@@ -20,8 +20,8 @@ class LRUCache(object):
         """
         :type node: ListNode
         """
-        # delete node
-        return
+        node.prev.next = node.next
+        node.next.prev - node.prev
 
     def insert(self, node):
         """

--- a/146.py
+++ b/146.py
@@ -4,6 +4,8 @@ class LRUCache(object):
         """
         :type capacity: int
         """
+        self._capacity = capacity
+        self._key_value = dict()
 
     def get(self, key):
         """

--- a/146.py
+++ b/146.py
@@ -1,9 +1,7 @@
 class ListNode(object):
     def __init__(self, key, value):
-        self.key = key
-        self.val = value
-        self.prev = None
-        self.next = None
+        self.key, self.val = key, value
+        self.prev = self.next = None
 
 
 class LRUCache(object):
@@ -14,8 +12,9 @@ class LRUCache(object):
         """
         self._capacity = capacity
         self._key_value = dict()
-        self._head = None
-        self._tail = None
+        # dummy head and tail to prevent head/tail deletion
+        self._head = ListNode(0, 0)
+        self._tail = ListNode(0, 0)
 
     def get(self, key):
         """

--- a/146.py
+++ b/146.py
@@ -1,3 +1,10 @@
+class ListNode(object):
+    def __init__(self, x):
+        self.val = x
+        self.prev = None
+        self.next = None
+
+
 class LRUCache(object):
 
     def __init__(self, capacity):
@@ -6,6 +13,8 @@ class LRUCache(object):
         """
         self._capacity = capacity
         self._key_value = dict()
+        self._head = None
+        self._tail = None
 
     def get(self, key):
         """

--- a/146.py
+++ b/146.py
@@ -25,11 +25,21 @@ class LRUCache(object):
         if key in self._key_value:
             # upate usage
             node = self._key_value[key]
-            # delete node from middle of the list
-            if node.prev:
-                node.prev.next = node.next
-            if node.next:
+            # node is already MRU so we don't need to change anything
+            if node is self._tail:
+                return node.val
+            # node being the head of the list requires additional logic
+            elif node is self._head:
+                # at this point, we know there is a tail node that is not head (at least 2 nodes)
+                # so we can move the head pointer to the next node in the list
+                self._head = self._head.next
+                # head has no prev
                 node.next.prev = node.prev
+            else:
+                # delete node from middle of the list
+                node.prev.next = node.next
+                node.next.prev = node.prev
+
             # move node to the end of the list
             node.next = None
             node.prev = self._tail

--- a/146.py
+++ b/146.py
@@ -25,8 +25,10 @@ class LRUCache(object):
             # upate usage
             node = self._key_value[key]
             # delete node from middle of the list
-            node.prev.next = node.next
-            node.next.prev = node.prev
+            if node.prev:
+                node.prev.next = node.next
+            if node.next:
+                node.next.prev = node.prev
             # move node to the end of the list
             self._tail.next = node
             self._tail = node
@@ -53,8 +55,10 @@ class LRUCache(object):
         # delete existing key from linked list
         if key in self._key_value:
             old_node = self._key_value[key]
-            old_node.prev.next = old_node.next
-            old_node.next.prev = old_node.prev
+            if old_node.prev:
+                old_node.prev.next = old_node.next
+            if old_node.next:
+                old_node.next.prev = old_node.prev
 
         if not self._tail:
             self._head = ListNode(value)

--- a/146.py
+++ b/146.py
@@ -16,6 +16,20 @@ class LRUCache(object):
         self._head = ListNode(0, 0)
         self._tail = ListNode(0, 0)
 
+    def remove(self, node):
+        """
+        :type node: ListNode
+        """
+        # delete node
+        return
+
+    def insert(self, node):
+        """
+        :type node: ListNode
+        """
+        # insert node
+        return
+
     def get(self, key):
         """
         :type key: int

--- a/146.py
+++ b/146.py
@@ -31,6 +31,8 @@ class LRUCache(object):
             if node.next:
                 node.next.prev = node.prev
             # move node to the end of the list
+            node.next = None
+            node.prev = self._tail
             self._tail.next = node
             self._tail = node
             # return value from key-value pair

--- a/146.py
+++ b/146.py
@@ -49,10 +49,14 @@ class LRUCache(object):
             old_node.prev.next = old_node.next
             old_node.next.prev = old_node.prev
 
-        # add new key usage data (most recently used)
-        self._tail.next = ListNode(value)
-        self._tail.next.prev = self._tail
-        self._tail = self._tail.next
+        if not self._tail:
+            self._head = ListNode(value)
+            self._tail = self._head
+        else:
+            # add new key usage data (most recently used)
+            self._tail.next = ListNode(value)
+            self._tail.next.prev = self._tail
+            self._tail = self._tail.next
 
         # updates old key or adds new key-value if there is space
         self._key_value[key] = self._tail

--- a/146.py
+++ b/146.py
@@ -56,43 +56,19 @@ class LRUCache(object):
         :type value: int
         :rtype: None
         """
-        # no space for a new key
-        if key not in self._key_value and len(self._key_value) >= self._capacity:
-            # delete key-value pair
-            pop_key = self._head.key
-            self._key_value.pop(pop_key)
-
-            # remove old key usage data (remove node from linked list)
-            self._head = self._head.next
-
-        # delete existing key from linked list
         if key in self._key_value:
-            node = self._key_value[key]
-            # increment head pointer if we delete head
-            if node is self._head:
-                self._head = self._head.next
-            # decerement tail pointer if we delete tail
-            elif node is self._tail:
-                self._tail = self._tail.prev
-
-            # sever any links
-            if node.prev:
-                node.prev.next = node.next
-            if node.next:
-                node.next.prev = node.prev
-
-        # empty list
-        if not self._head:
-            self._head = ListNode(key, value)
-            self._tail = self._head
-        else:
-            # add new key usage data (most recently used)
-            self._tail.next = ListNode(key, value)
-            self._tail.next.prev = self._tail
-            self._tail = self._tail.next
+            self.remove(self._key_value[key])
 
         # updates old key or adds new key-value if there is space
-        self._key_value[key] = self._tail
+        new_node = ListNode(key, value)
+        self.insert(new_node)
+        self._key_value[key] = new_node
+
+        # no space for a new key
+        if len(self._key_value) > self._capacity:
+            LRU = self._head.next
+            self.remove(LRU)
+            self._key_value.pop(LRU.key)
 
 
 # Your LRUCache object will be instantiated and called as such:

--- a/146.py
+++ b/146.py
@@ -1,0 +1,25 @@
+class LRUCache(object):
+
+    def __init__(self, capacity):
+        """
+        :type capacity: int
+        """
+
+    def get(self, key):
+        """
+        :type key: int
+        :rtype: int
+        """
+
+    def put(self, key, value):
+        """
+        :type key: int
+        :type value: int
+        :rtype: None
+        """
+
+
+# Your LRUCache object will be instantiated and called as such:
+# obj = LRUCache(capacity)
+# param_1 = obj.get(key)
+# obj.put(key,value)

--- a/146.py
+++ b/146.py
@@ -23,7 +23,7 @@ class LRUCache(object):
         """
         # sever node's ties to delete it from the middle of the list
         node.prev.next = node.next
-        node.next.prev - node.prev
+        node.next.prev = node.prev
 
     def insert(self, node):
         """

--- a/146.py
+++ b/146.py
@@ -12,6 +12,10 @@ class LRUCache(object):
         :type key: int
         :rtype: int
         """
+        if key in self._key_value:
+            return self._key_value[key]
+        else:
+            return -1
 
     def put(self, key, value):
         """

--- a/146.py
+++ b/146.py
@@ -43,6 +43,12 @@ class LRUCache(object):
             # remove old key usage data (remove node from linked list)
             self._head = self._head.next
 
+        # delete existing key from linked list
+        if key in self._key_value:
+            old_node = self._key_value[key]
+            old_node.prev.next = old_node.next
+            old_node.next.prev = old_node.prev
+
             # add new key usage data (most recently used)
             new_node = ListNode(value)
             new_node.prev = self._tail

--- a/146.py
+++ b/146.py
@@ -1,6 +1,7 @@
 class ListNode(object):
-    def __init__(self, x):
-        self.val = x
+    def __init__(self, key, value):
+        self.key = key
+        self.val = value
         self.prev = None
         self.next = None
 
@@ -46,7 +47,7 @@ class LRUCache(object):
         # no space for a new key
         if key not in self._key_value and len(self._key_value) >= self._capacity:
             # delete key-value pair
-            pop_key = self._head.val
+            pop_key = self._head.key
             self._key_value.pop(pop_key)
 
             # remove old key usage data (remove node from linked list)
@@ -61,11 +62,11 @@ class LRUCache(object):
                 old_node.next.prev = old_node.prev
 
         if not self._tail:
-            self._head = ListNode(value)
+            self._head = ListNode(key, value)
             self._tail = self._head
         else:
             # add new key usage data (most recently used)
-            self._tail.next = ListNode(value)
+            self._tail.next = ListNode(key, value)
             self._tail.next.prev = self._tail
             self._tail = self._tail.next
 

--- a/146.py
+++ b/146.py
@@ -44,27 +44,8 @@ class LRUCache(object):
         if key in self._key_value:
             # upate usage
             node = self._key_value[key]
-            # node is already MRU so we don't need to change anything
-            if node is self._tail:
-                return node.val
-            # node being the head of the list requires additional logic
-            elif node is self._head:
-                # at this point, we know there is a tail node that is not head (at least 2 nodes)
-                # so we can move the head pointer to the next node in the list
-                self._head = self._head.next
-                # head has no prev
-                node.next.prev = node.prev
-            else:
-                # delete node from middle of the list
-                node.prev.next = node.next
-                node.next.prev = node.prev
-
-            # move node to the end of the list
-            node.next = None
-            node.prev = self._tail
-            self._tail.next = node
-            self._tail = node
-            # return value from key-value pair
+            self.remove(node)
+            self.insert(node)
             return node.val
         else:
             return -1


### PR DESCRIPTION
# Link
https://leetcode.com/problems/lru-cache/
# Process
- Used a dictionary for key-value pairs
- `capacity` property
- `get()` functionality simply returned from internal dictionary
- Updated keys or added them under `capacity` for `put()`
- Understood eventually that removing a node from the middle of the list could be `O(1)` if we simply severed its ties to the nodes around it and reattached their pointers to each other
- Also understood to use the dictionary to point to nodes rather than values
  - Had a bug at some point where only the `key` was in the node because this was my ideal initially, but was able to catch that and fix it pretty easily
- Wrote logic to eject the LRU element and add new nodes
- Eventually got a working solution
## Challenges
- Failed 2 or 3 test cases, and I had to trace through the problems
- I ended up having to write a lot of edge case logic for empty linked lists
- Also had edge cases with removing `head` or `tail` which could happen in both `put()` and `get()` which I didn't necessarily expect
   - `head` removal would require incrementing the pointer
   - `tail` removal would require decrementing the pointer
## Improvements
- Having dummy nodes for the `head` and `tail` made it so I didn't have to deal with as many edge cases
  - Deletion would always happen "in the middle" of the linked list
- Writing helper functions to `remove()` and `insert()` nodes was extremely helpful as well and it made sense to factor out that functionality since it was required for `put()` and `get()`